### PR TITLE
Configuration Fixes/Improvements

### DIFF
--- a/ConfigFile.java
+++ b/ConfigFile.java
@@ -12,7 +12,8 @@ import java.util.*;
 public class ConfigFile extends ConfigurationProvider {
 
 
-	private Hashtable<String,String> kvp;
+	private String filename;
+	private ConfigurationParser parser;
 
 
 	/**
@@ -28,17 +29,30 @@ public class ConfigFile extends ConfigurationProvider {
 	 */
 	public ConfigFile (String filename, ConfigurationParser parser) throws Exception {
 	
+		this.filename=filename;
+		this.parser=parser;
+	
+		//	Open a stream to the file-in-question
+		FileInputStream stream;
+		try {
+		
+			stream=new FileInputStream(filename);
+		
+		} catch (Exception e) {
+		
+			//	If the file could not be opened,
+			//	we just create an empty set of
+			//	configurations
+			return;
+		
+		}
+	
 		//	Create an input stream reader
 		//	to read from the specified file
+		//	stream
 		BufferedReader reader=new BufferedReader(
-			new InputStreamReader(
-				new FileInputStream(
-					filename
-				)
-			)
+			new InputStreamReader(stream)
 		);
-		
-		kvp=new Hashtable<String,String>();
 		
 		//	Loop until all settings have
 		//	been extracted
@@ -63,13 +77,18 @@ public class ConfigFile extends ConfigurationProvider {
 	}
 	
 	
-	public String Get (String key) {
+	/**
+	 *	Writes configurations back to the file from
+	 *	which they were originally drawn, according
+	 *	to the strategy used to parse them.
+	 */
+	public void Write () throws Exception {
 	
-		//	Guard against nulls
-		if (key==null) return null;
-		
-		//	Fetch
-		return kvp.get(key);
+		ConfigFileWriter.Write(
+			filename,
+			this,
+			parser
+		);
 	
 	}
 

--- a/ConfigFileWriter.java
+++ b/ConfigFileWriter.java
@@ -1,0 +1,55 @@
+package greymerk.roguelike;
+
+
+import java.nio.channels.FileChannel;
+import java.io.*;
+
+
+/**
+ *	Allows configurations to be written to
+ *	config files.
+ */
+public class ConfigFileWriter {
+
+
+	/**
+	 *	Writes a particular set of configurations to
+	 *	a particular file according to a particular
+	 *	representation.
+	 *
+	 *	\param [in] filename
+	 *		The name of the file to which configuration
+	 *		data shall be written.
+	 *	\param [in] config
+	 *		The configurations which shall be written to
+	 *		the given file.
+	 *	\param [in] writer
+	 *		A ConfigurationParser which implements the
+	 *		desired strategy for representing configuration
+	 *		data in the file.
+	 */
+	public static void Write (String filename, ConfigurationProvider config, ConfigurationParser writer) throws Exception {
+	
+		//	Open file for writing
+		FileOutputStream stream=new FileOutputStream(filename,true);
+		
+		//	Truncate file in case it already
+		//	existed
+		stream.getChannel().truncate(0);
+		
+		//	Create a writer
+		BufferedWriter buffered=new BufferedWriter(
+			new OutputStreamWriter(stream)
+		);
+		
+		//	Write all configurations
+		for (Configuration c : config) writer.Write(buffered,c);
+		
+		//	Close the stream and flush out
+		//	all written configurations
+		buffered.close();
+	
+	}
+
+
+}

--- a/ConfigurationParser.java
+++ b/ConfigurationParser.java
@@ -1,7 +1,7 @@
 package greymerk.roguelike;
 
 
-import java.io.BufferedReader;
+import java.io.*;
 
 
 /**
@@ -11,6 +11,10 @@ import java.io.BufferedReader;
  *	Configuration parsers process raw strings from
  *	a configuration source, and transform it into
  *	a set of key/value pairs.
+ *
+ *	Configuration parsers process configuration data,
+ *	and transform it back into the raw strings from
+ *	which it may be reparsed.
  */
 public interface ConfigurationParser {
 
@@ -28,6 +32,17 @@ public interface ConfigurationParser {
 	 *		\em reader.
 	 */
 	public Configuration Parse (BufferedReader reader) throws Exception;
+	
+	
+	/**
+	 *	Writes one configurations to an output stream.
+	 *
+	 *	\param [in] writer
+	 *		A writer which writes to the destination.
+	 *	\param [in] config
+	 *		The configuration to serialize.
+	 */
+	public void Write (Writer writer, Configuration config) throws Exception;
 
 
 }

--- a/ConfigurationProvider.java
+++ b/ConfigurationProvider.java
@@ -1,10 +1,23 @@
 package greymerk.roguelike;
 
 
+import java.util.*;
+
+
 /**
  *	Provides configuration information.
  */
-public abstract class ConfigurationProvider {
+public abstract class ConfigurationProvider implements Iterable<Configuration> {
+
+
+	protected Hashtable<String,String> kvp;
+	
+	
+	protected ConfigurationProvider () {
+	
+		kvp=new Hashtable<String,String>();
+	
+	}
 
 
 	/**
@@ -19,7 +32,15 @@ public abstract class ConfigurationProvider {
 	 *		The data associated with \em key,
 	 *		if it exists, \em null otherwise.
 	 */
-	public abstract String Get (String key);
+	public String Get (String key) {
+	
+		//	Guard against null keys
+		if (key==null) return null;
+		
+		//	Fetch
+		return kvp.get(key);
+	
+	}
 	
 	
 	/**
@@ -65,6 +86,8 @@ public abstract class ConfigurationProvider {
 	
 		String value=Get(key);
 		
+		if (value==null) return fallback;
+		
 		try {
 		
 			return Double.parseDouble(value);
@@ -93,6 +116,8 @@ public abstract class ConfigurationProvider {
 	
 		String value=Get(key);
 		
+		if (value==null) return fallback;
+		
 		try {
 		
 			return Integer.parseInt(value);
@@ -100,6 +125,112 @@ public abstract class ConfigurationProvider {
 		} catch (NumberFormatException e) {	}
 		
 		return fallback;
+	
+	}
+	
+	
+	/**
+	 *	Sets a configuration, creating it if it
+	 *	does not exist, updating it otherwise.
+	 *
+	 *	\param [in] key
+	 *		The key associated with the configuration
+	 *		to update or create.
+	 *	\param [in] value
+	 *		The value to associate with \em key.
+	 */
+	public void Set (String key, String value) {
+	
+		//	If the key is null, pass, that's
+		//	meaningless
+		if (key==null) return;
+		
+		//	If the value is null, that's actually
+		//	an attempt to remove a configuration
+		if (value==null) {
+		
+			kvp.remove(key);
+		
+			return;
+		
+		}
+		
+		//	Otherwise we update/insert the
+		//	configuration
+		kvp.put(key,value);
+	
+	}
+	/**
+	 *	Sets a configuration, creating it if it
+	 *	does not exist, updating it otherwise.
+	 *
+	 *	\param [in] key
+	 *		The key associated with the configuration
+	 *		to update or create.
+	 *	\param [in] value
+	 *		The value to associate with \em key.
+	 */
+	public void Set (String key, double value) {
+	
+		Set(
+			key,
+			Double.toString(value)
+		);
+	
+	}
+	/**
+	 *	Sets a configuration, creating it if it
+	 *	does not exist, updating it otherwise.
+	 *
+	 *	\param [in] key
+	 *		The key associated with the configuration
+	 *		to update or create.
+	 *	\param [in] value
+	 *		The value to associate with \em key.
+	 */
+	public void Set (String key, int value) {
+	
+		Set(
+			key,
+			Integer.toString(value)
+		);
+	
+	}
+	
+	
+	/**
+	 *	Unsets a configuration, removing it.
+	 *
+	 *	If the requested configuration didn't
+	 *	exist, nothing happens.
+	 *
+	 *	\param [in] key
+	 *		The key associated with the
+	 *		configuration to remote.
+	 */
+	public void Unset (String key) {
+	
+		//	If the key is null, pass, that's
+		//	meaningless
+		if (key==null) return;
+		
+		//	Remove
+		kvp.remove(key);
+	
+	}
+	
+	
+	/**
+	 *	Fetches an iterator which may be used
+	 *	to traverse the configurations in this
+	 *	provider in an unspecified order.
+	 *
+	 *	\return
+	 *		An iterator.
+	 */
+	public Iterator<Configuration> iterator () {
+	
+		return new ConfigurationProviderIterator(kvp.entrySet().iterator());
 	
 	}
 

--- a/ConfigurationProviderIterator.java
+++ b/ConfigurationProviderIterator.java
@@ -1,0 +1,66 @@
+package greymerk.roguelike;
+
+
+import java.util.*;
+
+
+/**
+ *	An iterator which traverses the configurations
+ *	contained in a ConfigurationProvider in an
+ *	unspecified order.
+ */
+public class ConfigurationProviderIterator implements Iterator<Configuration> {
+
+
+	private Iterator<Map.Entry<String,String>> inner;
+	
+	
+	/**
+	 *	\cond
+	 */
+	
+	
+	public ConfigurationProviderIterator (Iterator<Map.Entry<String,String>> inner) {
+	
+		this.inner=inner;
+	
+	}
+	
+	
+	/**
+	 *	\endcond
+	 */
+	 
+	
+	public boolean hasNext () {
+	
+		return inner.hasNext();
+	
+	}
+	
+	
+	public Configuration next () throws NoSuchElementException {
+	
+		Map.Entry<String,String> next=inner.next();
+		
+		return new Configuration(
+			next.getKey(),
+			next.getValue()
+		);
+	
+	}
+	
+	
+	/**
+	 *	This method is not supported.
+	 */
+	public void remove () throws UnsupportedOperationException {
+	
+		//	Operation not supported,
+		//	unconditional throw
+		throw new UnsupportedOperationException();
+	
+	}
+
+
+}

--- a/INIParser.java
+++ b/INIParser.java
@@ -1,7 +1,7 @@
 package greymerk.roguelike;
 
 
-import java.io.BufferedReader;
+import java.io.*;
 import java.util.regex.*;
 
 
@@ -80,6 +80,16 @@ public class INIParser implements ConfigurationParser {
 			return new Configuration(key,value);
 		
 		}
+	
+	}
+	
+	
+	public void Write (Writer writer, Configuration config) throws Exception {
+	
+		writer.write(config.Key);
+		writer.write("=");
+		writer.write(config.Value);
+		writer.write(System.getProperty("line.separator"));
 	
 	}
 


### PR DESCRIPTION
Fixed a bug which allowed NullPointerException to be thrown from the methods that get and parse configurations -- either to ints or doubles.

Fixed an oversight which caused the constructor of ConfigFile to throw if the file-in-question didn't exist.  It is desirable to be able to create a ConfigFile even if the corresponding file does not exist.  This allows for improved workflow as the ConfigFile object can be used to manage configurations even if no corresponding physical file exists.

Made several improvements/additions:
- ConfigurationProvider now contains and manages its own Hashtable<String,String> and manages it, which removes that responsibility from the base class and allows for better code reuse.
- ConfigurationProvider is now iterable.  ConfigurationProviderIterator coalesces the entries in the underlying Hashtable<String,String> into Configuration objects.
- ConfigurationParser -- and the implementation INIParser -- now provide a method for serialization as well as parsing.
- ConfigurationProviders may now be written to disk using the Write static method of the ConfigFileWriter class.
- ConfigFile now remembers the filename and ConfigurationParser it was constructed with, and has a member method Write which writes all configurations back to that same file in the same format.
- ConfigurationProviders now allow for new configurations to be added through the Set overloads.
- ConfigurationProviders now allow for configurations to be removed through the Unset method.
