### PR TITLE
Config option for spawn height

### DIFF
--- a/src/main/java/greymerk/roguelike/catacomb/Catacomb.java
+++ b/src/main/java/greymerk/roguelike/catacomb/Catacomb.java
@@ -143,18 +143,20 @@ public class Catacomb {
 	}
 	
 	public static boolean validLocation(World world, Random rand, int x, int z){
+		int upperLimit = RogueConfig.getInt(RogueConfig.UPPERLIMIT);
+		int lowerLimit = RogueConfig.getInt(RogueConfig.LOWERLIMIT);
 		
-		if(!WorldGenPrimitive.isAirBlock(world, new Coord(x, 100, z))){
+		if(!WorldGenPrimitive.isAirBlock(world, new Coord(x, upperLimit, z))){
 			return false;
 		}
 		
-		int y = 100;
+		int y = upperLimit;
 		
-		while(!WorldGenPrimitive.getBlock(world, new Coord(x, y, z)).getBlock().getMaterial().isOpaque() && y > 50){
+		while(!WorldGenPrimitive.getBlock(world, new Coord(x, y, z)).getBlock().getMaterial().isOpaque() && y > lowerLimit){
 			--y;
 		}
 		
-		if(y < 60){
+		if(y < lowerLimit){
 			return false;
 		}
 		

--- a/src/main/java/greymerk/roguelike/config/RogueConfig.java
+++ b/src/main/java/greymerk/roguelike/config/RogueConfig.java
@@ -11,7 +11,7 @@ import net.minecraft.util.Tuple;
 public enum RogueConfig {
 
 	DONATURALSPAWN, LEVELRANGE, LEVELMAXROOMS, LEVELSCATTER, SPAWNFREQUENCY, GENEROUS, MOBDROPS, DIMENSIONWL, DIMENSIONBL, 
-	PRECIOUSBLOCKS, LOOTING;
+	PRECIOUSBLOCKS, LOOTING, UPPERLIMIT, LOWERLIMIT;
 	
 	public static final String configDirName = "config/roguelike_dungeons";
 	public static final String configFileName = "roguelike.cfg";
@@ -34,6 +34,8 @@ public enum RogueConfig {
 		case DIMENSIONBL: return "dimensionBL";
 		case PRECIOUSBLOCKS: return "preciousBlocks";
 		case LOOTING: return "looting";
+		case UPPERLIMIT: return "upperLimit";
+		case LOWERLIMIT: return "lowerLimit";
 		default: return null;
 		}
 	}
@@ -54,6 +56,8 @@ public enum RogueConfig {
 			return new Tuple(getName(option), new ArrayList<Integer>());
 		case PRECIOUSBLOCKS: return new Tuple(getName(option), true);
 		case LOOTING: return new Tuple(getName(option), 0.085D);
+		case UPPERLIMIT: return new Tuple(getName(option), 100);
+		case LOWERLIMIT: return new Tuple(getName(option), 60);
 		default: return null;
 		}
 	}
@@ -70,6 +74,8 @@ public enum RogueConfig {
 		if(!instance.ContainsKey(getName(DIMENSIONBL)))setIntList(DIMENSIONBL, (List<Integer>)getDefault(DIMENSIONBL).getSecond());
 		if(!instance.ContainsKey(getName(PRECIOUSBLOCKS)))setBoolean(PRECIOUSBLOCKS, (Boolean)getDefault(PRECIOUSBLOCKS).getSecond());
 		if(!instance.ContainsKey(getName(LOOTING)))setDouble(LOOTING, (Double) getDefault(LOOTING).getSecond());
+		if(!instance.ContainsKey(getName(UPPERLIMIT)))setInt(UPPERLIMIT, (Integer) getDefault(UPPERLIMIT).getSecond());
+		if(!instance.ContainsKey(getName(LOWERLIMIT)))setInt(LOWERLIMIT, (Integer) getDefault(LOWERLIMIT).getSecond());
 	}
 	
 	public static double getDouble(RogueConfig option){


### PR DESCRIPTION
Using amplified terrain, or a custom world generator that uses a much
higher terrain, will result in no dungeons being created. This adds 2
config options to choose the search area for the dungeon spawning.