### PR TITLE
added dimension blacklist/whitelist to dungeon main settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.12.2-1.8.0"
+version = "1.12.2-1.8.1"
 group= "ca.rivas.roguelike"
 archivesBaseName = "RoguelikeDungeons"
 

--- a/src/main/java/greymerk/roguelike/dungeon/settings/SettingsContainer.java
+++ b/src/main/java/greymerk/roguelike/dungeon/settings/SettingsContainer.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -108,7 +109,8 @@ public class SettingsContainer implements ISettingsContainer{
 		
 		for(String namespace : settingsByNamespace.keySet()){
 			if(!namespace.equals(SettingsContainer.BUILTIN_NAMESPACE)) continue;
-			settings.addAll(settingsByNamespace.get(namespace).values());
+			settings.addAll(settingsByNamespace.get(namespace).values().stream()
+											   .filter(s -> !s.getInherits().isEmpty()).collect(Collectors.toList()));
 		}
 		
 		return settings;
@@ -120,7 +122,8 @@ public class SettingsContainer implements ISettingsContainer{
 		
 		for(String namespace : settingsByNamespace.keySet()){
 			if(namespace.equals(SettingsContainer.BUILTIN_NAMESPACE)) continue;
-			settings.addAll(settingsByNamespace.get(namespace).values());
+			settings.addAll(settingsByNamespace.get(namespace).values().stream()
+											   .filter(s -> !s.getInherits().isEmpty()).collect(Collectors.toList()));
 		}
 		
 		return settings;

--- a/src/main/java/greymerk/roguelike/dungeon/settings/SettingsResolver.java
+++ b/src/main/java/greymerk/roguelike/dungeon/settings/SettingsResolver.java
@@ -114,6 +114,8 @@ public class SettingsResolver {
 				settingsRandomizer.add(new WeightedChoice<DungeonSettings>(setting, setting.criteria.weight));
 			}
 		}
+
+		if(settingsRandomizer.isEmpty()) return null;
 		
 		DungeonSettings chosen = settingsRandomizer.get(rand);
 		


### PR DESCRIPTION
added dimension blacklist/whitelist to dungeon main settings (spawn criteria), also fixed some settings issues:
 * prevent loading of other custom settings during spawn, even if the "main" file with its inherits has criteria filters
 * getCustom() should return null if it can't find a fitting custom setting
 * SpawnCriteria biome lists are now checked if they're empty instead of checking for a null instance, as these should not be null, ever